### PR TITLE
Update dependencies for Lune 0.10.0

### DIFF
--- a/pesde.lock
+++ b/pesde.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 format = 2
 name = "kimpure/asciitable"
-version = "0.2.1"
+version = "0.2.2"
 target = "luau"
 
 [graph."0x5eal/unzip@0.1.3 luau".pkg_ref]
@@ -33,22 +33,17 @@ index_url = "https://github.com/pesde-pkg/index"
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/darklua_lune@0.1.4 lune".dependencies]
-darklua = ["pesde/darklua@0.16.0 lune", "peer"]
-dirs = ["jiwonz/dirs@0.4.0 lune", "standard"]
+[graph."jiwonz/darklua_lune@0.2.0 lune".dependencies]
+dirs = ["jiwonz/dirs@0.5.1 lune", "standard"]
 greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-pesde_exec = ["jiwonz/pesde_exec@0.4.2 lune", "standard"]
 
-[graph."jiwonz/darklua_lune@0.1.4 lune".pkg_ref]
+[graph."jiwonz/darklua_lune@0.2.0 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/darklua_lune@0.1.4 lune".pkg_ref.dependencies]
-darklua = [{ name = "pesde/darklua", version = "^0.16.0", index = "https://github.com/pesde-pkg/index" }, "peer"]
-dirs = [{ name = "jiwonz/dirs", version = "^0.4.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+[graph."jiwonz/darklua_lune@0.2.0 lune".pkg_ref.dependencies]
+dirs = [{ name = "jiwonz/dirs", version = "^0.5.1", index = "https://github.com/pesde-pkg/index" }, "standard"]
 greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/pesde-pkg/index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.8", index = "https://github.com/pesde-pkg/index" }, "dev"]
-pesde_exec = [{ name = "jiwonz/pesde_exec", version = "^0.4.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
 
 [graph."jiwonz/dirs@0.3.0 lune".dependencies]
 greentea = ["corecii/greentea@0.4.11 lune", "standard"]
@@ -65,44 +60,36 @@ pathfs = [{ name = "jiwonz/pathfs", version = "^0.3.0", index = "https://github.
 selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
 stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
 
-[graph."jiwonz/dirs@0.4.0 lune".dependencies]
+[graph."jiwonz/dirs@0.5.1 lune".dependencies]
 greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-pathfs = ["jiwonz/pathfs@0.6.0-rc.7 lune", "standard"]
+pathfs = ["jiwonz/pathfs@0.6.0-rc.8 lune", "standard"]
 
-[graph."jiwonz/dirs@0.4.0 lune".pkg_ref]
+[graph."jiwonz/dirs@0.5.1 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/dirs@0.4.0 lune".pkg_ref.dependencies]
+[graph."jiwonz/dirs@0.5.1 lune".pkg_ref.dependencies]
 greentea = [{ name = "corecii/greentea", version = "^0.4.10", index = "https://github.com/daimond113/pesde-index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.8", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.1", index = "https://github.com/daimond113/pesde-index" }, "standard"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.6", index = "https://github.com/daimond113/pesde-index" }, "standard"]
 
-[graph."jiwonz/glob@0.1.1 lune".dependencies]
-globrex_lune = ["kimpure/globrex_lune@0.2.4 lune", "standard"]
-pathfs = ["jiwonz/pathfs@0.6.0-rc.7 lune", "standard"]
+[graph."jiwonz/glob@0.1.2 lune".dependencies]
+globrex_lune = ["kimpure/globrex_lune@0.2.9 lune", "standard"]
+pathfs = ["jiwonz/pathfs@0.6.0-rc.8 lune", "standard"]
 
-[graph."jiwonz/glob@0.1.1 lune".pkg_ref]
+[graph."jiwonz/glob@0.1.2 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/glob@0.1.1 lune".pkg_ref.dependencies]
+[graph."jiwonz/glob@0.1.2 lune".pkg_ref.dependencies]
 globrex_lune = [{ name = "kimpure/globrex_lune", version = "^0.2.4", index = "https://github.com/pesde-pkg/index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.13", index = "https://github.com/pesde-pkg/index" }, "dev"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.37.0", index = "https://github.com/pesde-pkg/index" }, "dev"]
 pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.3", index = "https://github.com/pesde-pkg/index" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/pesde-pkg/index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
 
-[graph."jiwonz/greentea_luau@0.1.0 luau"]
-direct = ["greentea_luau", { name = "jiwonz/greentea_luau", version = "^0.1.0", index = "default" }, "standard"]
+[graph."jiwonz/greentea_luau@0.2.0 luau"]
+direct = ["greentea_luau", { name = "jiwonz/greentea_luau", version = "^0.2.0", index = "default" }, "standard"]
 
-[graph."jiwonz/greentea_luau@0.1.0 luau".pkg_ref]
+[graph."jiwonz/greentea_luau@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
-
-[graph."jiwonz/greentea_luau@0.1.0 luau".pkg_ref.dependencies]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.5", index = "https://github.com/daimond113/pesde-index", target = "lune" }, "dev"]
 
 [graph."jiwonz/luau_disk@0.1.4 luau".pkg_ref]
 ref_ty = "pesde"
@@ -122,37 +109,31 @@ luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.1.4", index = "https://g
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/multitarget@0.4.0-rc.29 lune"]
-direct = ["multitarget", { name = "jiwonz/multitarget", version = "^0.4.0-rc.28", index = "default", target = "lune" }, "dev"]
+[graph."jiwonz/multitarget@0.4.0-rc.30 lune"]
+direct = ["multitarget", { name = "jiwonz/multitarget", version = "^0.4.0-rc.30", index = "default", target = "lune" }, "dev"]
 
-[graph."jiwonz/multitarget@0.4.0-rc.29 lune".dependencies]
+[graph."jiwonz/multitarget@0.4.0-rc.30 lune".dependencies]
 argparse = ["caveful_games/argparse@0.1.2 lune", "standard"]
 chalk_luau = ["kimpure/chalk_luau@0.1.7 luau", "standard"]
-darklua = ["pesde/darklua@0.16.0 lune", "peer"]
-darklua_lune = ["jiwonz/darklua_lune@0.1.4 lune", "standard"]
-glob = ["jiwonz/glob@0.1.1 lune", "standard"]
+darklua_lune = ["jiwonz/darklua_lune@0.2.0 lune", "standard"]
+glob = ["jiwonz/glob@0.1.2 lune", "standard"]
 greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-pathfs = ["jiwonz/pathfs@0.6.0-rc.7 lune", "standard"]
-result = ["lukadev_0/result@1.2.0 lune", "standard"]
+pathfs = ["jiwonz/pathfs@0.6.0-rc.8 lune", "standard"]
+result = ["lukadev_0/result@1.2.1 lune", "standard"]
 table_helper = ["caveful_games/table_helper@0.2.0-rc.1 luau", "standard"]
 
-[graph."jiwonz/multitarget@0.4.0-rc.29 lune".pkg_ref]
+[graph."jiwonz/multitarget@0.4.0-rc.30 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/multitarget@0.4.0-rc.29 lune".pkg_ref.dependencies]
+[graph."jiwonz/multitarget@0.4.0-rc.30 lune".pkg_ref.dependencies]
 argparse = [{ name = "caveful_games/argparse", version = "^0.1.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
 chalk_luau = [{ name = "kimpure/chalk_luau", version = "^0.1.7", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]
-darklua = [{ name = "pesde/darklua", version = "^0.16.0", index = "https://github.com/pesde-pkg/index" }, "peer"]
-darklua_lune = [{ name = "jiwonz/darklua_lune", version = "^0.1.4", index = "https://github.com/pesde-pkg/index" }, "standard"]
-glob = [{ name = "jiwonz/glob", version = "^0.1.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+darklua_lune = [{ name = "jiwonz/darklua_lune", version = "^0.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+glob = [{ name = "jiwonz/glob", version = "^0.1.1", index = "https://github.com/pesde-pkg/index" }, "standard"]
 greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/pesde-pkg/index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.13", index = "https://github.com/pesde-pkg/index" }, "dev"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.42.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
-pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.3", index = "https://github.com/pesde-pkg/index" }, "standard"]
+pathfs = [{ name = "jiwonz/pathfs", version = "^0.6.0-rc.8", index = "https://github.com/pesde-pkg/index" }, "standard"]
 result = [{ name = "lukadev_0/result", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/pesde-pkg/index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
 table_helper = [{ name = "caveful_games/table_helper", version = "^0.2.0-rc.1", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]
 
 [graph."jiwonz/pathfs@0.3.2 lune".dependencies]
@@ -169,102 +150,67 @@ greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://g
 luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.8", index = "https://github.com/daimond113/pesde-index" }, "dev"]
 luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.1", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
 
-[graph."jiwonz/pathfs@0.5.2 lune".dependencies]
+[graph."jiwonz/pathfs@0.6.0-rc.8 lune".dependencies]
 greentea = ["corecii/greentea@0.4.11 lune", "standard"]
 luau_path = ["jiwonz/luau_path@0.1.4 luau", "standard"]
 
-[graph."jiwonz/pathfs@0.5.2 lune".pkg_ref]
+[graph."jiwonz/pathfs@0.6.0-rc.8 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/pathfs@0.5.2 lune".pkg_ref.dependencies]
+[graph."jiwonz/pathfs@0.6.0-rc.8 lune".pkg_ref.dependencies]
 frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
 greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.1", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune".dependencies]
-greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-luau_path = ["jiwonz/luau_path@0.1.4 luau", "standard"]
-
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune".pkg_ref]
-ref_ty = "pesde"
-index_url = "https://github.com/pesde-pkg/index"
-
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune".pkg_ref.dependencies]
-frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.13", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.48.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
 luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.4", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.1.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-
-[graph."jiwonz/pesde_exec@0.4.2 lune".dependencies]
-greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-pathfs = ["jiwonz/pathfs@0.5.2 lune", "standard"]
-
-[graph."jiwonz/pesde_exec@0.4.2 lune".pkg_ref]
-ref_ty = "pesde"
-index_url = "https://github.com/pesde-pkg/index"
-
-[graph."jiwonz/pesde_exec@0.4.2 lune".pkg_ref.dependencies]
-greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/pesde-pkg/index" }, "standard"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
-pathfs = [{ name = "jiwonz/pathfs", version = "^0.5.2", index = "https://github.com/pesde-pkg/index" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/pesde-pkg/index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
 
 [graph."kimpure/chalk_luau@0.1.7 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."kimpure/globrex_lune@0.2.4 lune".dependencies]
+[graph."kimpure/globrex_lune@0.2.9 lune".dependencies]
 luau_regexp = ["jiwonz/luau_regexp@0.1.3 luau", "standard"]
 
-[graph."kimpure/globrex_lune@0.2.4 lune".pkg_ref]
+[graph."kimpure/globrex_lune@0.2.9 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."kimpure/globrex_lune@0.2.4 lune".pkg_ref.dependencies]
+[graph."kimpure/globrex_lune@0.2.9 lune".pkg_ref.dependencies]
 luau_check = [{ name = "jiwonz/luau_check", version = "^0.2.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
 luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
 luau_regexp = [{ name = "jiwonz/luau_regexp", version = "^0.1.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]
 selene = [{ name = "pesde/selene", version = "^0.27.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
 stylua = [{ name = "pesde/stylua", version = "^2.0.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
 
-[graph."lukadev_0/option@1.2.0 lune".pkg_ref]
+[graph."lukadev_0/option@1.2.1 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."lukadev_0/result@1.2.0 lune".pkg_ref]
+[graph."lukadev_0/result@1.2.1 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."pesde/darklua@0.16.0 lune"]
-direct = ["darklua", { name = "pesde/darklua", version = "^0.16.0", index = "default", target = "lune" }, "dev"]
+[graph."pesde/darklua@0.17.1 lune"]
+direct = ["darklua", { name = "pesde/darklua", version = "^0.17.1", index = "default", target = "lune" }, "dev"]
 
-[graph."pesde/darklua@0.16.0 lune".dependencies]
+[graph."pesde/darklua@0.17.1 lune".dependencies]
 core = ["pesde/toolchainlib@0.1.15 lune", "standard"]
-option = ["lukadev_0/option@1.2.0 lune", "standard"]
-result = ["lukadev_0/result@1.2.0 lune", "standard"]
+option = ["lukadev_0/option@1.2.1 lune", "standard"]
+result = ["lukadev_0/result@1.2.1 lune", "standard"]
 
-[graph."pesde/darklua@0.16.0 lune".pkg_ref]
+[graph."pesde/darklua@0.17.1 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."pesde/darklua@0.16.0 lune".pkg_ref.dependencies]
-core = [{ name = "pesde/toolchainlib", version = "^0.1.11", index = "https://github.com/pesde-pkg/index", target = "lune" }, "standard"]
+[graph."pesde/darklua@0.17.1 lune".pkg_ref.dependencies]
+core = [{ name = "pesde/toolchainlib", version = "^0.1.15", index = "https://github.com/pesde-pkg/index", target = "lune" }, "standard"]
 option = [{ name = "lukadev_0/option", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
 result = [{ name = "lukadev_0/result", version = "^1.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
 
 [graph."pesde/toolchainlib@0.1.15 lune".dependencies]
 dirs = ["jiwonz/dirs@0.3.0 lune", "standard"]
-option = ["lukadev_0/option@1.2.0 lune", "peer"]
+option = ["lukadev_0/option@1.2.1 lune", "peer"]
 pathfs = ["jiwonz/pathfs@0.3.2 lune", "standard"]
-result = ["lukadev_0/result@1.2.0 lune", "peer"]
+result = ["lukadev_0/result@1.2.1 lune", "peer"]
 unzip = ["0x5eal/unzip@0.1.3 luau", "standard"]
 
 [graph."pesde/toolchainlib@0.1.15 lune".pkg_ref]

--- a/pesde.toml
+++ b/pesde.toml
@@ -15,11 +15,11 @@ build_files = ["src"]
 default = "https://github.com/pesde-pkg/index"
 
 [engines]
-lune = "0.8.9"
+pesde = "^0.7.1"
 
 [dependencies]
-greentea_luau = { name = "jiwonz/greentea_luau", version = "^0.1.0" }
+greentea_luau = { name = "jiwonz/greentea_luau", version = "^0.2.0" }
 
 [dev_dependencies]
-darklua = { name = "pesde/darklua", version = "^0.16.0", target = "lune" }
-multitarget = { name = "jiwonz/multitarget", version = "^0.4.0-rc.28", target = "lune" }
+darklua = { name = "pesde/darklua", version = "^0.17.1", target = "lune" }
+multitarget = { name = "jiwonz/multitarget", version = "^0.4.0-rc.30", target = "lune" }


### PR DESCRIPTION
This PR fixes support for Lune 0.10.0 by upgrading its runtime dependency `greentea_luau` to 0.2.0 which was updated to support Lune 0.10.0. The issue is that your dev tools are not yet supported by Lune 0.10.0 and will not be if this PR isnt merged due to pesde tools also not supporting Lune 0.10.0. I recommend using a dedicated manager like rokit or mise in the meanwhile.